### PR TITLE
Remove Radius Bicep VS Code extension

### DIFF
--- a/instructions/02-setup.md
+++ b/instructions/02-setup.md
@@ -65,17 +65,9 @@ Make sure you have the following tools installed on your machine:
 
 ## 2.4 Install the Radius-Bicep VSCode extension
 
-Radius is currently leveraging a fork of the [Bicep language](https://github.com/azure/bicep) while we work with them to upstream our extensibility features. During this phase, you need to ensure **you have disabled the official Bicep extension** and installed the Radius-Bicep extension.
-
-1. Disable the Bicep extension, if you have it installed & enabled:
+Install the Radius-Bicep extension from the [VSCode Marketplace](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-bicep):
    ```bash
-   code --uninstall-extension ms-azuretools.vscode-bicep
-   ```
-
-   *If you're on macOS you may need to add `code` to your path via the [instructions here](https://code.visualstudio.com/docs/setup/mac#_launching-from-the-command-line). You can also uninstall the extension via the VSCode UI.*
-1. Install the Radius-Bicep extension from the [VSCode Marketplace](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.rad-vscode-bicep):
-   ```bash
-   code --install-extension ms-azuretools.rad-vscode-bicep
+   code --install-extension ms-azuretools.vscode-bicep
    ```
 
 ## Next step

--- a/instructions/02-setup.md
+++ b/instructions/02-setup.md
@@ -65,7 +65,7 @@ Make sure you have the following tools installed on your machine:
 
 ## 2.4 Install the Radius-Bicep VSCode extension
 
-Install the Radius-Bicep extension from the [VSCode Marketplace](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-bicep):
+Install the Bicep extension from the [VSCode Marketplace](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-bicep):
    ```bash
    code --install-extension ms-azuretools.vscode-bicep
    ```


### PR DESCRIPTION
This PR removes references to the Radius Bicep VS Code extension.